### PR TITLE
Mention this only works for text and provides an alternative

### DIFF
--- a/javascript/copy_element_to_clipboard.md
+++ b/javascript/copy_element_to_clipboard.md
@@ -72,4 +72,4 @@ Which relies on these functions:
 		return document.querySelectorAll(selector);
 	}
 
-Above is copies **text**. If you want to copy (non-markdown) formatting, you might want to consider [ClipboardJS](https://clipboardjs.com).
+Above copies **text** only. If you want to copy (non-markdown) formatted text or other content (like images), you might want to consider [ClipboardJS](https://clipboardjs.com).

--- a/javascript/copy_element_to_clipboard.md
+++ b/javascript/copy_element_to_clipboard.md
@@ -71,3 +71,5 @@ Which relies on these functions:
 	function $(selector) {
 		return document.querySelectorAll(selector);
 	}
+
+Above is copies **text**. If you want to copy (non-markdown) formatting, you might want to consider [ClipboardJS](https://clipboardjs.com).


### PR DESCRIPTION
`execCommand('copy')` only copies "text/*" mime-types.